### PR TITLE
CODEX: Smooth camera follow for sparse GPS location updates

### DIFF
--- a/src/map/map-movement-controller.ts
+++ b/src/map/map-movement-controller.ts
@@ -2,8 +2,6 @@ import L from "leaflet";
 import type { ConfigStore } from "../config";
 import type { LocationTracker, OrientationTracker } from "../location";
 
-type LatLngTuple = [number, number];
-
 type MapMovementControllerParams = {
     map: L.Map;
     locationTracker: LocationTracker;
@@ -11,6 +9,10 @@ type MapMovementControllerParams = {
     configStore: ConfigStore;
 };
 
+/**
+ * Keeps the map camera centered on the tracked location while smoothing
+ * low-frequency GPS updates and preserving immediate jumps for discontinuities.
+ */
 export class MapMovementController {
     constructor({
         map,
@@ -50,12 +52,13 @@ export class MapMovementController {
         if (!this.unsubscribeLocationFollow) {
             this.unsubscribeLocationFollow = this.locationTracker.addListener(
                 ({ latitude, longitude }) => {
-                    const nextTarget: LatLngTuple = [latitude, longitude];
+                    const nextTarget: L.LatLngTuple = [latitude, longitude];
 
                     // First fix after enabling follow: snap to avoid startup drift.
                     if (!this.targetLatLng || !this.currentLatLng) {
                         this.targetLatLng = nextTarget;
                         this.currentLatLng = nextTarget;
+                        this.map.stop();
                         this.map.setView(nextTarget, this.map.getZoom(), {
                             animate: false,
                         });
@@ -63,15 +66,16 @@ export class MapMovementController {
                         return;
                     }
 
-                    const jumpDistanceMeters = this.distanceMeters(
-                        this.targetLatLng,
-                        nextTarget,
-                    );
+                    const jumpDistanceMeters = L.latLng(
+                        this.targetLatLng[0],
+                        this.targetLatLng[1],
+                    ).distanceTo(L.latLng(nextTarget[0], nextTarget[1]));
                     this.targetLatLng = nextTarget;
 
                     // Snap immediately on large discontinuities.
                     if (jumpDistanceMeters > this.largeJumpMeters) {
                         this.currentLatLng = nextTarget;
+                        this.map.stop();
                         this.map.setView(nextTarget, this.map.getZoom(), {
                             animate: false,
                         });
@@ -111,23 +115,33 @@ export class MapMovementController {
         this.currentLatLng = undefined;
     };
 
+    /**
+     * Starts the requestAnimationFrame follow loop if it is not already active.
+     */
     private startFollowAnimation = (): void => {
-        if (this.rafId !== undefined) {
+        if (this.frameId !== undefined) {
             return;
         }
 
         this.lastFrameTs = undefined;
-        this.rafId = requestAnimationFrame(this.stepFollowAnimation);
+        this.frameId = requestAnimationFrame(this.stepFollowAnimation);
     };
 
+    /**
+     * Stops the requestAnimationFrame follow loop and resets frame timing.
+     */
     private stopFollowAnimation = (): void => {
-        if (this.rafId !== undefined) {
-            cancelAnimationFrame(this.rafId);
-            this.rafId = undefined;
+        if (this.frameId !== undefined) {
+            cancelAnimationFrame(this.frameId);
+            this.frameId = undefined;
         }
         this.lastFrameTs = undefined;
     };
 
+    /**
+     * Runs one animation frame of smooth camera follow.
+     * Interpolates toward targetLatLng and re-schedules until convergence.
+     */
     private stepFollowAnimation = (timestampMs: number): void => {
         if (!this.targetLatLng || !this.currentLatLng) {
             this.stopFollowAnimation();
@@ -140,6 +154,8 @@ export class MapMovementController {
                 : Math.max(0, timestampMs - this.lastFrameTs);
         this.lastFrameTs = timestampMs;
 
+        // Exponential smoothing using frame delta, so animation speed remains stable
+        // even when requestAnimationFrame cadence varies.
         const alpha = 1 - Math.exp(-dtMs / this.tauMs);
         const [currentLat, currentLng] = this.currentLatLng;
         const [targetLat, targetLng] = this.targetLatLng;
@@ -149,10 +165,10 @@ export class MapMovementController {
 
         this.currentLatLng = [nextLat, nextLng];
 
-        const remainingDistanceMeters = this.distanceMeters(
-            this.currentLatLng,
-            this.targetLatLng,
-        );
+        const remainingDistanceMeters = L.latLng(
+            this.currentLatLng[0],
+            this.currentLatLng[1],
+        ).distanceTo(L.latLng(this.targetLatLng[0], this.targetLatLng[1]));
         if (remainingDistanceMeters < this.snapDistanceMeters) {
             this.currentLatLng = this.targetLatLng;
             this.map.panTo(this.targetLatLng, { animate: false });
@@ -161,11 +177,7 @@ export class MapMovementController {
         }
 
         this.map.panTo(this.currentLatLng, { animate: false });
-        this.rafId = requestAnimationFrame(this.stepFollowAnimation);
-    };
-
-    private distanceMeters = (a: LatLngTuple, b: LatLngTuple): number => {
-        return L.latLng(a[0], a[1]).distanceTo(L.latLng(b[0], b[1]));
+        this.frameId = requestAnimationFrame(this.stepFollowAnimation);
     };
 
     private map: L.Map;
@@ -173,11 +185,18 @@ export class MapMovementController {
     private orientationTracker: OrientationTracker;
     private unsubscribeLocationFollow: (() => void) | undefined;
     private unsubscribeRotation: (() => void) | undefined;
-    private targetLatLng: LatLngTuple | undefined;
-    private currentLatLng: LatLngTuple | undefined;
-    private rafId: number | undefined;
+    // Most recent position emitted by the location tracker.
+    private targetLatLng: L.LatLngTuple | undefined;
+    // Camera position currently used by the smoothing loop.
+    private currentLatLng: L.LatLngTuple | undefined;
+    // Active animation frame handle for the follow loop.
+    private frameId: number | undefined;
+    // Previous frame timestamp used to compute frame delta.
     private lastFrameTs: number | undefined;
+    // Time constant for the exponential follow filter.
     private readonly tauMs = 450;
+    // Stop animating once visually converged to avoid tiny endless updates.
     private readonly snapDistanceMeters = 0.5;
+    // Treat larger deltas as GPS discontinuities and snap immediately.
     private readonly largeJumpMeters = 25;
 }


### PR DESCRIPTION
## Summary
Improves `MapMovementController` camera-follow behavior to handle sparse GPS updates smoothly while still snapping immediately on discontinuities.

## Problem
The previous implementation called `map.setView(..., { animate: true })` on every location update. With low-frequency or bursty GPS updates, this caused visible jumpiness and inconsistent camera motion.

## What Changed
- Replaced per-update animated `setView` with a requestAnimationFrame-driven smoothing loop.
- Added explicit animation lifecycle methods:
  - `startFollowAnimation`
  - `stopFollowAnimation`
  - `stepFollowAnimation`
- Introduced target/current position state:
  - `targetLatLng` (latest tracker location)
  - `currentLatLng` (camera position used for interpolation)
- Added discontinuity handling:
  - First fix after enabling follow snaps immediately.
  - Large jumps (> `largeJumpMeters`) snap immediately.
- Ensured snap paths are non-animated and deterministic:
  - `map.setView(..., { animate: false })`
  - `map.stop()` before snap to cancel in-flight map animation.
- Added inline documentation for animation flow, smoothing math, and tuning constants.
- Switched tuple usage to Leaflet’s built-in `L.LatLngTuple`.
- Inlined Leaflet distance checks via `L.latLng(...).distanceTo(...)`.

## Behavioral Diagram
```mermaid
flowchart TD
    A["Location update"] --> B{"Have target/current?"}
    B -- "No" --> C["Snap to nextTarget\nsetView animate:false"]
    C --> D["Stop follow animation"]

    B -- "Yes" --> E["Compute jump distance"]
    E --> F{"jump > largeJumpMeters?"}
    F -- "Yes" --> G["map.stop + snap setView\nanimate:false"]
    G --> D

    F -- "No" --> H["Set targetLatLng"]
    H --> I["Start RAF loop if idle"]
    I --> J["stepFollowAnimation"]
    J --> K["Exponential smoothing\nalpha = 1 - exp(-dt/tau)"]
    K --> L{"remaining < snapDistanceMeters?"}
    L -- "Yes" --> M["Final panTo animate:false\nStop RAF"]
    L -- "No" --> N["panTo currentLatLng animate:false\nrequest next frame"]
    N --> J
```

## Animation Lifecycle
```mermaid
sequenceDiagram
    participant LT as LocationTracker
    participant MMC as MapMovementController
    participant MAP as Leaflet Map
    participant RAF as requestAnimationFrame

    LT->>MMC: location(lat,lng)
    MMC->>MMC: update targetLatLng
    alt first fix or large jump
        MMC->>MAP: stop()
        MMC->>MAP: setView(target, animate:false)
        MMC->>MMC: stopFollowAnimation()
    else normal update
        MMC->>MMC: startFollowAnimation()
        MMC->>RAF: requestAnimationFrame(step)
        RAF-->>MMC: step(timestamp)
        MMC->>MAP: panTo(interpolated, animate:false)
        MMC->>RAF: requestAnimationFrame(step)
    end
```

## Tuning Parameters
- `tauMs = 450`: smoothing time constant for interpolation.
- `snapDistanceMeters = 0.5`: stop RAF when close enough to target.
- `largeJumpMeters = 25`: threshold for immediate snap.

## Validation
- `bun run build` passes.

## Risks / Notes
- Tuning values are currently hard-coded; behavior may need adjustment for different movement speeds/device update intervals.
- `panTo(..., { animate: false })` is called each frame by design; this trades animation smoothness control for deterministic camera updates.
