### PR TITLE
codex: implement POI-collision-controller (we worked together)

### DIFF
--- a/src/location/location-store.ts
+++ b/src/location/location-store.ts
@@ -45,9 +45,9 @@ export class LocationStore {
 
             const distanceInMeters = current.distanceTo(previous);
 
-            debug(
-                `[LocationStore] distance between ${current} and ${previous} = ${distanceInMeters}`,
-            );
+            //debug(
+            //    `[LocationStore] distance between ${current} and ${previous} = ${distanceInMeters}`,
+            //);
 
             if (distanceInMeters < 1) {
                 // less than 1 meter

--- a/src/location/location-tracker.ts
+++ b/src/location/location-tracker.ts
@@ -91,6 +91,7 @@ export class LocationTracker extends Observable<LocationPoint> {
         });
     };
 
+    // TODO: notify of stopping
     private handleError = (error: GeolocationPositionError) => {
         switch (error.code) {
             case GeolocationPositionError.PERMISSION_DENIED: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { tileLayers } from "./map/layers";
 import { initMap } from "./map/map";
 import L from "leaflet";
 import {
+    POICollisionController,
     POIController,
     POIPolygonController,
     POIs,
@@ -52,6 +53,15 @@ const locationController = new LocationController({
  * controls showing the popup and marking the circles
  */
 new POIController({ poiTracker });
+
+/**
+ * controls collision between live user location and POI polygons
+ */
+new POICollisionController({
+    POIs,
+    locationTracker,
+    poiTracker,
+});
 
 /**
  * controlls showing the polygons for POIs

--- a/src/points/POI-collision-controller.ts
+++ b/src/points/POI-collision-controller.ts
@@ -1,0 +1,132 @@
+import type { LocationPoint, LocationTracker } from "../location";
+import type { POI } from "../types";
+import L from "leaflet";
+import { debug } from "../utils";
+import type { POITracker } from "./POI-tracker";
+
+type POICollisionControllerParams = {
+    POIs: POI[];
+    locationTracker: LocationTracker;
+    poiTracker: POITracker;
+    deselectOnExit?: boolean;
+    minCheckDistanceMeters?: number;
+};
+
+export class POICollisionController {
+    /**
+     * Stores POIs with prebuilt bounds and subscribes to live location updates.
+     * Collision checks then run through `LatLngBounds.contains()` only.
+     */
+    constructor({
+        POIs,
+        locationTracker,
+        poiTracker,
+        deselectOnExit = false,
+        minCheckDistanceMeters = 0.75,
+    }: POICollisionControllerParams) {
+        this.POIs = POIs;
+        this.poiById = new Map(POIs.map((poi) => [poi.id, poi]));
+        this.poiTracker = poiTracker;
+        this.deselectOnExit = deselectOnExit;
+        this.minCheckDistanceMeters = minCheckDistanceMeters;
+
+        locationTracker.addListener(this.handleLocation);
+    }
+
+    /**
+     * Handles each location point, skips tiny movements, and emits POI enter/exit
+     * transitions. `select()` is called only when entering a different POI.
+     */
+    private handleLocation = ({ latitude, longitude }: LocationPoint): void => {
+        const currentPoint = { latitude, longitude };
+
+        if (this.lastCheckedPoint) {
+            // Ignore tiny movement to avoid collision checks on GPS noise.
+            const distance = L.latLng(
+                this.lastCheckedPoint.latitude,
+                this.lastCheckedPoint.longitude,
+            ).distanceTo(L.latLng(latitude, longitude));
+            if (distance < this.minCheckDistanceMeters) {
+                debug(
+                    "[POICollisionController] distance not great enough, returning early",
+                );
+                return;
+            }
+        }
+
+        this.lastCheckedPoint = currentPoint;
+
+        // Determine which POI currently contains this location.
+        const containingPOI = this.findContainingPOI(latitude, longitude);
+
+        if (containingPOI) {
+            // Still in the same POI, so don't fire duplicate select events.
+            if (containingPOI.id === this.activeCollisionPOIId) {
+                return;
+            }
+
+            debug(
+                `[POICollisionController] entered ${containingPOI.id}, selecting`,
+            );
+            this.activeCollisionPOIId = containingPOI.id;
+            this.poiTracker.select(containingPOI);
+            return;
+        }
+
+        // Not inside any POI and no active collision POI means no transition.
+        if (!this.activeCollisionPOIId) {
+            return;
+        }
+
+        debug(
+            `[POICollisionController] exited ${this.activeCollisionPOIId}, clearing active collision`,
+        );
+        this.activeCollisionPOIId = undefined;
+
+        if (this.deselectOnExit) {
+            this.poiTracker.deselectActive();
+        }
+    };
+
+    /**
+     * Finds which POI contains the point using `LatLngBounds.contains()`.
+     *
+     * Fast path: check the currently active POI first.
+     */
+    private findContainingPOI(
+        latitude: number,
+        longitude: number,
+    ): POI | undefined {
+        if (this.activeCollisionPOIId) {
+            const active = this.poiById.get(this.activeCollisionPOIId);
+            // Fast path: user commonly remains in the current POI.
+            if (active && active.bounds.contains([latitude, longitude])) {
+                return active;
+            }
+        }
+
+        for (const poi of this.POIs) {
+            if (poi.id === this.activeCollisionPOIId) {
+                // Already tested in the fast path above.
+                continue;
+            }
+            // Bounds-only collision check.
+            if (poi.bounds.contains([latitude, longitude])) {
+                return poi;
+            }
+        }
+
+        return undefined;
+    }
+
+    private readonly POIs: POI[];
+    private readonly poiById: Map<string, POI>;
+    private readonly poiTracker: POITracker;
+    private readonly deselectOnExit: boolean;
+    private readonly minCheckDistanceMeters: number;
+
+    private activeCollisionPOIId: string | undefined;
+    private lastCheckedPoint:
+        | Pick<LocationPoint, "latitude" | "longitude">
+        | undefined;
+}

--- a/src/points/POIs.ts
+++ b/src/points/POIs.ts
@@ -1,4 +1,10 @@
 import type { POI } from "../types";
+import L from "leaflet";
+
+const toBounds = (
+    southWest: [number, number],
+    northEast: [number, number],
+): L.LatLngBounds => L.latLngBounds(southWest, northEast);
 
 // TODO: lint and sort based on keys
 export const POIs: Array<POI> = [
@@ -9,6 +15,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181922,
             longitude: -116.414579,
         },
+        bounds: toBounds(
+            [34.18185729296687, -116.41471854348615],
+            [34.182094622489586, -116.41449600483872],
+        ),
         polygon: {
             path: [
                 [34.182094622489586, -116.41471854348615],
@@ -32,6 +42,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181792,
             longitude: -116.414532,
         },
+        bounds: toBounds(
+            [34.18173197459987, -116.4147442253696],
+            [34.18185378495963, -116.41455888112023],
+        ),
         polygon: {
             path: [
                 [34.18185378495963, -116.4147442253696],
@@ -54,6 +68,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181725,
             longitude: -116.414696,
         },
+        bounds: toBounds(
+            [34.181655132362465, -116.4147434965721],
+            [34.18173109206944, -116.41459510990985],
+        ),
         polygon: {
             path: [
                 [34.18173109206944, -116.4147434965721],
@@ -75,6 +93,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181759,
             longitude: -116.414433,
         },
+        bounds: toBounds(
+            [34.1816505930839, -116.41448915310552],
+            [34.18173995911545, -116.41433735721739],
+        ),
         polygon: {
             path: [
                 [34.18173995911545, -116.41448915310552],
@@ -97,6 +119,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181665,
             longitude: -116.414396,
         },
+        bounds: toBounds(
+            [34.18161268955937, -116.41444910880557],
+            [34.18164889823784, -116.41432944149489],
+        ),
         polygon: {
             path: [
                 [34.18161268955937, -116.41444910880557],
@@ -118,6 +144,10 @@ export const POIs: Array<POI> = [
             latitude: 34.18181,
             longitude: -116.41425,
         },
+        bounds: toBounds(
+            [34.18174588524302, -116.41428649510485],
+            [34.181814284907105, -116.41422099357649],
+        ),
         polygon: {
             path: [
                 [34.181814284907105, -116.41428649510485],
@@ -138,6 +168,10 @@ export const POIs: Array<POI> = [
             latitude: 34.1819,
             longitude: -116.414152,
         },
+        bounds: toBounds(
+            [34.181898031161424, -116.41413766231699],
+            [34.181961843046764, -116.4140093677009],
+        ),
         polygon: {
             path: [
                 [34.181961843046764, -116.41413766231699],
@@ -159,6 +193,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181959,
             longitude: -116.414309,
         },
+        bounds: toBounds(
+            [34.18194635629578, -116.4143479090959],
+            [34.181977840945066, -116.41430709212386],
+        ),
         polygon: {
             path: [
                 [34.181977840945066, -116.4143479090959],
@@ -181,6 +219,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181909,
             longitude: -116.414384,
         },
+        bounds: toBounds(
+            [34.18186030022349, -116.41442919864701],
+            [34.18194803363956, -116.41432963844129],
+        ),
         polygon: {
             path: [
                 [34.18194803363956, -116.41442919864701],
@@ -201,6 +243,10 @@ export const POIs: Array<POI> = [
             latitude: 34.181869,
             longitude: -116.414445,
         },
+        bounds: toBounds(
+            [34.181866566899046, -116.41448276636669],
+            [34.181935947919285, -116.414429739735],
+        ),
         polygon: {
             path: [
                 [34.181935947919285, -116.41448276636669],
@@ -221,6 +267,10 @@ export const POIs: Array<POI> = [
             latitude: 34.182357,
             longitude: -116.41468,
         },
+        bounds: toBounds(
+            [34.18209838159339, -116.41483646038394],
+            [34.182348859861435, -116.41451922531695],
+        ),
         polygon: {
             path: [
                 [34.182348859861435, -116.41483646038394],
@@ -242,6 +292,10 @@ export const POIs: Array<POI> = [
             latitude: 34.182057,
             longitude: -116.413928,
         },
+        bounds: toBounds(
+            [34.18204386947605, -116.4139641090556],
+            [34.182114353896296, -116.41388163727397],
+        ),
         polygon: {
             path: [
                 [34.182114353896296, -116.4139641090556],

--- a/src/points/index.ts
+++ b/src/points/index.ts
@@ -1,4 +1,5 @@
 export * from "./POIs";
+export * from "./POI-collision-controller";
 export * from "./POI-controller";
 export * from "./POI-polygon-controller";
 export * from "./POI-tracker";

--- a/src/types/POI.ts
+++ b/src/types/POI.ts
@@ -7,6 +7,7 @@ export type POI = {
         latitude: number;
         longitude: number;
     };
+    bounds: L.LatLngBounds; // southWest -> northEast
     imageName?: string;
     // TODO: non-optional
     audioName?: string;


### PR DESCRIPTION
## Summary
Adds POI collision detection driven by live location updates, using `L.LatLngBounds` for fast enter detection and `POITracker.select()` on transitions.

## What Changed
- Added `POICollisionController` to listen to `LocationTracker` updates.
- Switched POI collision checks to bounds-only (`poi.bounds.contains([lat, lng])`).
- Added `bounds: L.LatLngBounds` to each POI.
- Wired collision controller into app startup.
- Added inline comments explaining collision flow and fast paths.

## Behavior
- When user enters a POI bounds, `select(POI)` is called.
- Repeated updates inside the same POI do not re-select.
- Tiny movement jitter is ignored via a minimum distance threshold.

```mermaid
flowchart TD
    A["LocationTracker emits point"] --> B{"Moved enough since last check?"}
    B -- "No" --> C["Skip collision check"]
    B -- "Yes" --> D{"Active POI bounds contains point?"}
    D -- "Yes" --> E["No-op (stay in same POI)"]
    D -- "No" --> F["Scan other POI bounds"]
    F --> G{"Found containing POI?"}
    G -- "Yes" --> H["POITracker.select(POI)"]
    G -- "No" --> I{"Had active collision POI?"}
    I -- "No" --> J["No-op"]
    I -- "Yes" --> K["Clear active collision POI"]
```
